### PR TITLE
Fix attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
         <div id="game-load" class="game-button">Load</div>
         <div id="game-save" class="game-button">Save</div>
         <a id="game-about" class="game-button" href="https://jpw.nyc/transit">About this game</a>
-        <div class="attribution"><a href="http://leafletjs.com/">Leaflet</a> | Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ</div>
+        <div class="attribution"><a href="http://leafletjs.com/">Leaflet</a> | Tiles &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> &mdash; <a href="https://carto.com/attributions">CARTO</a></div>
     </div>
 
     </div>

--- a/index_bk.html
+++ b/index_bk.html
@@ -210,7 +210,7 @@
         <div id="game-load" class="game-button">Load</div>
         <div id="game-save" class="game-button">Save</div>
         <a id="game-about" class="game-button" href="http://jpwright.net/projects/subway">About this game</a>
-        <div class="attribution"><a href="http://leafletjs.com/">Leaflet</a> | Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ</div>
+        <div class="attribution"><a href="http://leafletjs.com/">Leaflet</a> | Tiles &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> &mdash; <a href="https://carto.com/attributions">CARTO</a></div>
     </div>
 
     </div>


### PR DESCRIPTION
https://github.com/jpwright/subway/blob/master/js/subway-main.js#L210 adds tiles from Carto, which require attribution to OpenStreetMap, not Esri.